### PR TITLE
ver: 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Or with yarn:
 import { Monno } from "monno"
 
 const client = new Monno({
-    ownerID: "12345678901234567",
-    testGuildID: "12345678901234567",
+    ownerIDs: ["12345678901234567"],
+    devGuildID: "12345678901234567",
     dev: true,
 })
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "monno",
 	"description": "A simple to use discord.js bot framework",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"author": "marzeq",
 	"license": "GPL-3.0-or-later",
 	"repository": "https://github.com/marzeq/monno",

--- a/src/client.ts
+++ b/src/client.ts
@@ -28,15 +28,19 @@ export declare interface Monno extends Client {
 export class Monno extends Client {
     public commands: MonnoCommandManager
     public extensions: MonnoExtensionManager
-    public ownerID: string
-    public devGuildID: string
+    public developerIDs?: string[]
+    public devGuildID?: string
     public dev: boolean
 
     constructor(options: MonnoClientOptions) {
         super(options)
-        this.ownerID = options.ownerID
-        this.devGuildID = options.devGuildID
         this.dev = options.dev
+
+        if (options.dev) {
+            this.developerIDs = options.developerIDs
+            this.devGuildID = options.devGuildID
+        }
+
         this.commands = new MonnoCommandManager()
         this.extensions = new MonnoExtensionManager(this)
     }
@@ -51,13 +55,16 @@ export class Monno extends Client {
     }
 }
 
-export type MonnoClientOptions = ClientOptions & {
+export type MonnoClientOptions = ClientOptions & ({
     /** This is used to determine wheter the commands should be registered in a (hopefully) private dev server. */
-    dev: boolean
-    /** This is used to allow only the bot owner to run the dev commands. */
-    ownerID: string
+    dev: true
+    /** This is used to allow only the bot developers to run the dev commands. */
+    developerIDs: string[]
     /** This will be used to determine which guild the dev commands should be registered in. */
     devGuildID: string
     /** This is used to determine which intents the bot should have. Keep in mind the bot automatically puts the GUILDS intent in */
     intents?: BitFieldResolvable<IntentsString, number>
-}
+} | {
+    dev: false
+    intents?: BitFieldResolvable<IntentsString, number>
+})

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -1,5 +1,5 @@
 import { Monno } from "./client"
-import { Awaitable, ClientEvents, Collection } from "discord.js"
+import { Awaitable, Collection } from "discord.js"
 import { MonnoCommand } from "./commands"
 
 export class MonnoExtensionManager {

--- a/tutorial/extension_data.md
+++ b/tutorial/extension_data.md
@@ -28,3 +28,12 @@ client.extensions.data("my-extension").myData // "my-data"
 ## 03.03. Example extension that uses extension data: mongodb extension
 
 Check out [this file](./mongodb_ext.ts) to see how extension data is used in an example mongodb extension.
+
+## 03.04. Publishing your extension to npm
+
+We reccomend to read these articles to learn how to publish your extension to npm:
+
+-   [Creating a package.json file](https://docs.npmjs.com/creating-a-package-json-file)
+-   [Creating Node.js modules](https://docs.npmjs.com/creating-node-js-modules)
+-   [Creating and publishing unscoped public packages](https://docs.npmjs.com/creating-and-publishing-unscoped-public-packages)
+-   **For TypeScript** after you've read the rest of the articles: [TypeScript - Publishing](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html)


### PR DESCRIPTION
**What does this PR change?**
This version allows the developer to specify multiple owner IDs (now called developer IDs)
The client typings have been updated to not require specifying the `developerIDs` and the `devGuildID` when not in dev mode
You can now allow commands to run in DM messages (ignores permissions)

---

- [ ] Code changes have been tested.
- [x] This PR adds something new.
- [x] This PR is a breaking change
* (Change public interface type & name: `MonnoClientOptions#ownerID: string` -> `MonnoClientOptions#developerIDs: string[]`)
- [ ] This PR fixes/implements an issue:
